### PR TITLE
feat(asr): add provider documentation links

### DIFF
--- a/app/Typoless/Domain/Models/AppConfig.swift
+++ b/app/Typoless/Domain/Models/AppConfig.swift
@@ -47,6 +47,21 @@ enum ASRPlatform: String, Codable, Equatable, Sendable, CaseIterable {
             "科大讯飞模式：语音会发送到科大讯飞语音识别服务。"
         }
     }
+
+    var documentationURL: URL {
+        switch self {
+        case .localFunASR:
+            URL(string: "https://github.com/modelscope/FunASR")!
+        case .tencentCloudSentence:
+            URL(string: "https://cloud.tencent.com/document/product/1093/35646")!
+        case .aliyunSentence:
+            URL(string: "https://help.aliyun.com/zh/isi/developer-reference/short-sentence-recognition")!
+        case .volcengineSentence:
+            URL(string: "https://www.volcengine.com/docs/6561/1257584")!
+        case .xunfeiSentence:
+            URL(string: "https://www.xfyun.cn/doc/asr/voicedictation/API.html")!
+        }
+    }
 }
 
 /// ASR 总配置

--- a/app/Typoless/UI/Settings/ASRSettingsView.swift
+++ b/app/Typoless/UI/Settings/ASRSettingsView.swift
@@ -25,12 +25,25 @@ struct ASRSettingsView: View {
     var body: some View {
         SettingsPaneSection {
             SettingsFormRow(title: "语音引擎") {
-                Picker("语音引擎", selection: $selectedPlatform) {
-                    ForEach(ASRPlatform.allCases, id: \.self) { platform in
-                        Text(platform.displayName).tag(platform)
+                HStack(spacing: 8) {
+                    Picker("语音引擎", selection: $selectedPlatform) {
+                        ForEach(ASRPlatform.allCases, id: \.self) { platform in
+                            Text(platform.displayName).tag(platform)
+                        }
                     }
+                    .labelsHidden()
+                    .frame(width: 334, alignment: .leading)
+
+                    Link(destination: selectedPlatform.documentationURL) {
+                        Image(systemName: "arrow.up.forward.square")
+                            .font(.system(size: 14, weight: .regular))
+                    }
+                    .buttonStyle(.plain)
+                    .foregroundStyle(.secondary)
+                    .frame(width: 18, height: 18)
+                    .accessibilityLabel("打开\(selectedPlatform.displayName)文档")
+                    .help("打开\(selectedPlatform.displayName)文档")
                 }
-                .labelsHidden()
                 .frame(width: SettingsFormLayout.controlWidth, alignment: .leading)
             }
 


### PR DESCRIPTION
## Summary
- Add official documentation URLs for each ASR provider
- Show an external-link icon next to the ASR provider picker
- Open the selected provider's documentation from the ASR settings page

## Verification
- swiftc -parse app/Typoless/Domain/Models/AppConfig.swift app/Typoless/UI/Settings/ASRSettingsView.swift app/Typoless/UI/Settings/SettingsView.swift
- git diff --check