### PR TITLE
fix: avoid stuck HUD when short recording is cancelled

### DIFF
--- a/app/Typoless/Domain/Coordinators/SessionCoordinator.swift
+++ b/app/Typoless/Domain/Coordinators/SessionCoordinator.swift
@@ -253,8 +253,6 @@ final class SessionCoordinator {
 
         let recordingResult = audioRecorder.stopRecording()
         let audioData = recordingResult.data
-        lastRecordedAudio = audioData
-        onFeedbackEvent?(.recordingStopped)
 
         // 短录音静默取消（<500ms）：先取消处理任务，再清理流
         if recordingResult.isShortRecording {
@@ -272,8 +270,12 @@ final class SessionCoordinator {
             targetApplicationBundleID = nil
             cleanupSegmenterState()
             state = .idle
+            onFeedbackEvent?(.processingCancelled)
             return
         }
+
+        lastRecordedAudio = audioData
+        onFeedbackEvent?(.recordingStopped)
 
         guard !audioData.isEmpty else {
             sessionGeneration &+= 1

--- a/app/TypolessTests/HUDFeedbackControllerTests.swift
+++ b/app/TypolessTests/HUDFeedbackControllerTests.swift
@@ -200,6 +200,18 @@ final class HUDFeedbackControllerTests: XCTestCase {
         XCTAssertFalse(controller.isHUDPresented)
     }
 
+    func testProcessingCancelledFromRecordingDismissesHUD() async {
+        let controller = HUDFeedbackController()
+
+        controller.handleEvent(.recordingStarted)
+        controller.handleEvent(.processingCancelled)
+
+        await waitForHUDToHide(controller)
+
+        XCTAssertEqual(controller.hudState, .hidden)
+        XCTAssertFalse(controller.isHUDPresented)
+    }
+
     func testDictionaryTermLearnedShowsNoticeHUD() {
         let controller = HUDFeedbackController()
 

--- a/app/TypolessTests/SessionCoordinatorLearningTests.swift
+++ b/app/TypolessTests/SessionCoordinatorLearningTests.swift
@@ -92,6 +92,46 @@ final class SessionCoordinatorLearningTests: XCTestCase {
         }
     }
 
+    func testQuickStartThenImmediateStopSilentlyCancelsWithoutProcessingHUD() throws {
+        let learner = MockPostInjectionLearner()
+        let coordinator = makeCoordinator(
+            dictionaryStore: PersonalDictionaryStore(directoryURL: tempDirectory),
+            learner: learner,
+            ensureMicrophoneAuthorized: {},
+            ensureAccessibilityAuthorized: {},
+            configureConfigStore: { configStore in
+                var config = ASRConfig()
+                config.selectedPlatform = .tencentCloudSentence
+                config.tencentCloud.secretId = "test-secret-id"
+                config.tencentCloud.secretKey = "test-secret-key"
+                try! configStore.saveASRConfig(config)
+                try! configStore.updateCloudValidationState(
+                    for: .tencentCloudSentence,
+                    status: .verified
+                )
+            }
+        )
+
+        var receivedEvents: [SessionFeedbackEvent] = []
+        coordinator.onFeedbackEvent = { event in
+            receivedEvents.append(event)
+        }
+
+        coordinator.startRecording()
+        coordinator.finishRecording()
+
+        XCTAssertEqual(coordinator.state, .idle)
+        XCTAssertNil(coordinator.currentError)
+        XCTAssertNil(coordinator.lastRecordedAudio)
+        XCTAssertEqual(receivedEvents.count, 2)
+        guard case .recordingStarted = receivedEvents[0] else {
+            return XCTFail("expected recordingStarted event")
+        }
+        guard case .processingCancelled = receivedEvents[1] else {
+            return XCTFail("expected processingCancelled event")
+        }
+    }
+
     private func makeCoordinator(
         dictionaryStore: PersonalDictionaryStore?,
         learner: any PostInjectionDictionaryLearning,
@@ -100,9 +140,11 @@ final class SessionCoordinatorLearningTests: XCTestCase {
         },
         ensureAccessibilityAuthorized: @escaping @MainActor @Sendable () throws -> Void = {
             try PermissionsManager().ensureAccessibilityAuthorized()
-        }
+        },
+        configureConfigStore: (@MainActor (ConfigStore) -> Void)? = nil
     ) -> SessionCoordinator {
         let configStore = ConfigStore(configDirectory: tempDirectory)
+        configureConfigStore?(configStore)
         let audioDeviceManager = AudioDeviceManager(configStore: configStore)
         return SessionCoordinator(
             permissionsManager: PermissionsManager(),


### PR DESCRIPTION
## Summary
- avoid sending `recordingStopped` for short recordings that should be silently cancelled
- send `processingCancelled` for the quick start/stop path so the HUD dismisses instead of staying in thinking
- add regression coverage for both `SessionCoordinator` and `HUDFeedbackController`

## Testing
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project Typoless.xcodeproj -scheme Typoless -configuration Debug -destination platform=macOS -derivedDataPath /Users/secret/Projects/playground/typoless/app/.build/DerivedData -only-testing:TypolessTests/SessionCoordinatorLearningTests -only-testing:TypolessTests/HUDFeedbackControllerTests`

Closes #155